### PR TITLE
feat: add RockawayX USDC (roxUSDC) vault on Pharos (1672)

### DIFF
--- a/chains/evm/1672/0x047cD0a91E9B92ED979189a6C8A120bf280f02E5/info.json
+++ b/chains/evm/1672/0x047cD0a91E9B92ED979189a6C8A120bf280f02E5/info.json
@@ -1,0 +1,6 @@
+{
+  "address": "0x047cD0a91E9B92ED979189a6C8A120bf280f02E5",
+  "name": "RockawayX USDC",
+  "symbol": "roxUSDC",
+  "decimals": 18
+}


### PR DESCRIPTION
Adds the RockawayX USDC Morpho vault token on Pharos (chain 1672).

**Token details:**
- Address: `0x047cD0a91E9B92ED979189a6C8A120bf280f02E5`
- Name: RockawayX USDC
- Symbol: roxUSDC
- Decimals: 18
- Source: on-chain ERC-20 read + morpho-list (oku-trade/morpho-list)